### PR TITLE
Suggestions

### DIFF
--- a/drive/SDSMK4SwerveModule.java
+++ b/drive/SDSMK4SwerveModule.java
@@ -47,6 +47,13 @@ public class SDSMK4SwerveModule implements AutoCloseable {
     }
   }
 
+  public static class ModuleConfig {
+    private GearRatio gearRatio;
+    private boolean inverted;
+
+
+  }
+
   /** Module location */
   public enum ModuleLocation {
     LeftFront(0, Rotation2d.fromRadians(+0.0)),
@@ -67,7 +74,7 @@ public class SDSMK4SwerveModule implements AutoCloseable {
   /**
    * SDSMK4Swerve gear ratio
    */
-  public enum DriveGearRatio {
+  public enum GearRatio {
     /** 8.14:1 */
     L1(8.14),
     /** 6.75:1 */
@@ -76,27 +83,18 @@ public class SDSMK4SwerveModule implements AutoCloseable {
     L3(6.12),
     /** 5.14:1 */
     L4(5.14);
-    /** Steering gear ratio: 12.8:1 */
 
     public final double value;
-    private DriveGearRatio(double value) {
-      this.value = value;
-    }
-  }
-
-  public enum SteerGearRatio {
-    STEER_MK4I((double)150/7), 
-    STEER_MK4(12.8);
-
-     public final double value;
-    private SteerGearRatio(double value) {
+    private GearRatio(double value) {
       this.value = value;
     }
   }
 
   private final double EPSILON = 5e-3;
   private final int DRIVE_MOTOR_CURRENT_LIMIT;
-  private final int ROTATE_MOTOR_CURRENT_LIMIT;
+  private final int ROTATE_MOTOR_CURRENT_LIMIT = 30;
+  private final double MK4_ROTATE_RATIO = 12.8;
+  private final double MK4I_ROTATE_RATIO = 150.0 / 7.0;
   private final Rotation2d LOCK_POSITION = Rotation2d.fromRadians(Math.PI / 4);
 
   private static final double DRIVE_WHEEL_DIAMETER_METERS = Units.Inches.of(4).in(Units.Meters); // 4" wheels
@@ -129,8 +127,7 @@ public class SDSMK4SwerveModule implements AutoCloseable {
   private ModuleLocation m_location;
   private Rotation2d m_previousRotatePosition;
 
-  private DriveGearRatio m_driveGearRatio;
-  private SteerGearRatio m_steerGearRatio;
+  private GearRatio m_driveGearRatio;
   private double m_driveConversionFactor;
   private double m_rotateConversionFactor;
   private double m_simDrivePosition;
@@ -141,7 +138,7 @@ public class SDSMK4SwerveModule implements AutoCloseable {
 
   private TractionControlController m_tractionControlController;
   private Instant m_autoLockTimer;
-  private double moduleSynchronizationCounter = 0;
+  private int m_moduleSynchronizationCounter = 0;
 
   /**
    * Create an instance of a SDSM4SwerveModule
@@ -153,27 +150,26 @@ public class SDSMK4SwerveModule implements AutoCloseable {
    * @param autoLockTime Time before rotating module to locked position [0.0, 10.0]
    * @param maxSlippingTime Maximum time that wheel is allowed to slip
    * @param driveMotorCurrentLimit Desired current limit for the drive motor
+   * @param inverted True if motors are mounted upside down, MK4i
    * @param slipRatio Desired slip ratio [+0.01, +0.40]
    */
-  public SDSMK4SwerveModule(Hardware swerveHardware, ModuleLocation location, DriveGearRatio driveGearRatio, SteerGearRatio steerGearRatio,
-                         Measure<Distance> wheelbase, Measure<Distance> trackWidth, Measure<Time> autoLockTime,
-                         Measure<Time> maxSlippingTime, Measure<Current> driveMotorCurrentLimit, Measure<Current> rotateMotorCurrentLimit, double slipRatio) {
+  public SDSMK4SwerveModule(Hardware swerveHardware, ModuleLocation location, GearRatio driveGearRatio,
+                            Measure<Distance> wheelbase, Measure<Distance> trackWidth, Measure<Time> autoLockTime,
+                            Measure<Time> maxSlippingTime, Measure<Current> driveMotorCurrentLimit, boolean inverted, double slipRatio) {
     int encoderTicksPerRotation = swerveHardware.driveMotor.getKind().equals(MotorKind.NEO)
       ? GlobalConstants.NEO_ENCODER_TICKS_PER_ROTATION
-      : GlobalConstants.VORTEX_ENCODER_TICKS_PER_ROTATION;                    
+      : GlobalConstants.VORTEX_ENCODER_TICKS_PER_ROTATION;
     DRIVE_TICKS_PER_METER = (encoderTicksPerRotation * driveGearRatio.value) * (1 / (DRIVE_WHEEL_DIAMETER_METERS * Math.PI));
     DRIVE_METERS_PER_TICK = 1 / DRIVE_TICKS_PER_METER;
     DRIVE_METERS_PER_ROTATION = DRIVE_METERS_PER_TICK * encoderTicksPerRotation;
     DRIVE_MAX_LINEAR_SPEED = (GlobalConstants.NEO_MAX_RPM / 60) * DRIVE_METERS_PER_ROTATION * DRIVETRAIN_EFFICIENCY;
     DRIVE_MOTOR_CURRENT_LIMIT = (int)driveMotorCurrentLimit.in(Units.Amps);
-    ROTATE_MOTOR_CURRENT_LIMIT = (int)rotateMotorCurrentLimit.in(Units.Amps);
 
     this.m_driveMotor = swerveHardware.driveMotor;
     this.m_rotateMotor = swerveHardware.rotateMotor;
     this.m_absoluteEncoder = swerveHardware.absoluteEncoder;
     this.m_location = location;
     this.m_driveGearRatio = driveGearRatio;
-    this.m_steerGearRatio = steerGearRatio;
     this.m_autoLock = true;
     this.m_simDrivePosition = 0.0;
     this.m_simRotatePosition = 0.0;
@@ -188,12 +184,12 @@ public class SDSMK4SwerveModule implements AutoCloseable {
     m_driveMotor.setVelocityConversionFactor(Spark.FeedbackSensor.NEO_ENCODER, m_driveConversionFactor / 60);
 
     // Set rotate encoder conversion factor
-    m_rotateConversionFactor = (2 * Math.PI )/ m_steerGearRatio.value;
+    m_rotateConversionFactor = (2 * Math.PI) / (inverted ? MK4I_ROTATE_RATIO : MK4_ROTATE_RATIO);
     m_rotateMotor.setPositionConversionFactor(Spark.FeedbackSensor.NEO_ENCODER, m_rotateConversionFactor);
     m_rotateMotor.setVelocityConversionFactor(Spark.FeedbackSensor.NEO_ENCODER, m_rotateConversionFactor / 60);
 
     // Enable PID wrapping
-    m_rotateMotor.enablePIDWrapping(-Math.PI, Math.PI);
+    m_rotateMotor.enablePIDWrapping(-Math.PI, +Math.PI);
 
     // Create PID configs
     SparkPIDConfig driveMotorConfig = new SparkPIDConfig(
@@ -276,6 +272,9 @@ public class SDSMK4SwerveModule implements AutoCloseable {
   public static Hardware initializeHardware(Spark.ID driveMotorID, Spark.ID rotateMotorID, MotorKind driveMotorKind, MotorKind rotateMotorKind, CANCoder.ID absoluteEncoderID) {
     if (driveMotorKind != MotorKind.NEO && driveMotorKind != MotorKind.NEO_VORTEX)
       throw new IllegalArgumentException("Drive motor MUST be a NEO or a NEO Vortex!");
+    if (rotateMotorKind != MotorKind.NEO && rotateMotorKind != MotorKind.NEO_VORTEX)
+      throw new IllegalArgumentException("Rotate motor MUST be a NEO or a NEO Vortex!");
+
     Hardware swerveModuleHardware = new Hardware(
       new Spark(driveMotorID, driveMotorKind),
       new Spark(rotateMotorID, rotateMotorKind),
@@ -302,9 +301,10 @@ public class SDSMK4SwerveModule implements AutoCloseable {
     m_driveMotor.periodic();
     m_rotateMotor.periodic();
     m_absoluteEncoder.periodic();
-    if(Math.abs(getRotationVelocity().magnitude()) <= EPSILON && ++moduleSynchronizationCounter > 5){
+
+    if (Math.abs(getRotationVelocity().magnitude()) <= EPSILON && ++m_moduleSynchronizationCounter > 5) {
       m_rotateMotor.resetEncoder(m_absoluteEncoder.getInputs().absolutePosition);
-      moduleSynchronizationCounter = 0;
+      m_moduleSynchronizationCounter = 0;
     }
   }
 
@@ -342,7 +342,7 @@ public class SDSMK4SwerveModule implements AutoCloseable {
     );
 
     // Optimize swerve module rotation state
-    // REV encoder returns an angle in radians
+    // Rotate motor returns an angle in radians
     desiredState = SwerveModuleState.optimize(desiredState, Rotation2d.fromRadians(m_rotateMotor.getInputs().encoderPosition));
 
     // Set rotate motor position
@@ -503,18 +503,6 @@ public class SDSMK4SwerveModule implements AutoCloseable {
   public Translation2d getModuleCoordinate() {
     return m_moduleCoordinate;
   }
-
-  /**
-   * Get drive gear ratio
-   * @return Gear ratio for driving wheel
-   */
-  public DriveGearRatio getDriveGearRatio() {
-    return m_driveGearRatio;
-  }
-   public SteerGearRatio getSteerGearRatio() {
-    return m_steerGearRatio;
-  }
- 
 
   /**
    * Stop swerve module


### PR DESCRIPTION
Did a few things:

- Changed the way that the rotation gear ratio is selected.
- Hardcoded the rotate current limit to 30 amps, I don't see any advantage to allowing users to customize this. Changing this current limit doesn't give you any extra performance. If anything it could be lowered to 25 amps. Regardless, a working value should be found, and hardcoded here.
- Throw exception if rotate motor kind is not supported
- Removed the get gear ratio methods; I don't see why you'd need the gear ratio anywhere else. Especially seeing as you're passing in the drive gear ratio to instantiate the module in the first place. The rotate gear ratio generally isn't useful anywhere else.
- Minor syntax cleanup

Regarding your work on "x locking", might I suggest an enum for that. 
```
public enum LockOrientation {
  O(Rotation2d.fromRadians(Math.PI / 4)),
  X(Rotation2d.fromRadians(<some_value>));
  
  public final Rotation2d value;
  private LockOrientation(Rotation2d value) {
    this.value = value;
  }
}
```

Also, creating a calibration jig like the REV MAXSwerve calibration tool and using offsets should simplify the math there for the different lock orientations. It should just become a position you can set like the existing "O" position.

As far as the reason why in the MAXSwerveModule the "O" position is the default. Both positions are equivalent in terms of holding the robot in place when getting hit on any side. The "X" position is potentially slightly better to prevent unintended rotation  of the robot when the modules are locked. However for us, we use PID to control the orientation of our robot, so we _actively_ control orientation of our robot, which is more effective than relying on the just the passive grip of the wheel/tread. Another reason is that the "O" position is a valid state for a type of motion, rotation, while the "X" position is not a valid state for any type of motion. This minutely reduces the time that the module spends rotating. And because of our use of rotation PID for the overall robot, the modules would likely end up in the "O" position most of the time anyway, due to its constant stream of small corrections to maintain the robot's orientation.
